### PR TITLE
xml-updates to namelist options for gw-deep-convection

### DIFF
--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -755,8 +755,9 @@
 <effgw_rdg_beta_max model_top="lt" >0.5D0</effgw_rdg_beta_max>
 <effgw_rdg_beta_max model_top="mt" >0.5D0</effgw_rdg_beta_max>
 
-<gw_convect_dp_ml                  >off </gw_convect_dp_ml>
-<gw_convect_dp_ml_net              >NONE</gw_convect_dp_ml_net>
+<gw_convect_dp_ml                  >.false.</gw_convect_dp_ml>
+<gw_convect_dp_ml_compare          >.false.</gw_convect_dp_ml_compare>
+<gw_convect_dp_ml_net_path         >NONE   </gw_convect_dp_ml_net_path>
 
 <!-- setting for gravity waves from shallow convection. -->
 <effgw_beres_sh>0.03D0</effgw_beres_sh>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -755,6 +755,8 @@
 <effgw_rdg_beta_max model_top="lt" >0.5D0</effgw_rdg_beta_max>
 <effgw_rdg_beta_max model_top="mt" >0.5D0</effgw_rdg_beta_max>
 
+<gw_convect_dp_ml                  >off </gw_convect_dp_ml>
+
 <!-- setting for gravity waves from shallow convection. -->
 <effgw_beres_sh>0.03D0</effgw_beres_sh>
 

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -756,6 +756,7 @@
 <effgw_rdg_beta_max model_top="mt" >0.5D0</effgw_rdg_beta_max>
 
 <gw_convect_dp_ml                  >off </gw_convect_dp_ml>
+<gw_convect_dp_ml_net              >NONE</gw_convect_dp_ml_net>
 
 <!-- setting for gravity waves from shallow convection. -->
 <effgw_beres_sh>0.03D0</effgw_beres_sh>

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -1393,20 +1393,24 @@ scheme (shallow convection).
 Default: set by build-namelist.
 </entry>
 
-<entry id="gw_convect_dp_ml" type="char*16" category="gw_drag"
-       group="gw_drag_nl" valid_values="off,on,bothoff,bothon" >
+<entry id="gw_convect_dp_ml" type="logical" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
 Whether or not to use the ML scheme for gravity waves produced by deep convection.
-   'off'     no
-   'on'      yes
-   'bothoff' run both but use default for simulation
-   'bothon'  run both but use ML for simulation
-Default: off
+Default: .false.
 </entry>
 
-<entry id="gw_convect_dp_ml_net" type="char*132" input_pathname="abs" category="gw_drag"
+<entry id="gw_convect_dp_ml_net_path" type="char*132" input_pathname="abs" category="gw_drag"
        group="gw_drag_nl" valid_values="" >
 Absolute filepath to the deep convection gravity wave neural net used when
-`gw_convect_dp_ml` is set.
+`gw_convect_dp_ml` is set to `.true.`.
+</entry>
+
+<entry id="gw_convect_dp_ml_compare" type="logical" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+  Whether or not to run a comparison of the ML deep convection gravity waves to the
+  original scheme. The scheme used to advance the simulation will be dictated by
+  `gw_convect_deep_ml`.
+Default: .false.
 </entry>
 
 <entry id="effgw_cm" type="real" category="gw_drag"

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -1336,6 +1336,12 @@ Whether or not to use the ML scheme for gravity waves produced by deep convectio
 Default: off
 </entry>
 
+<entry id="gw_convect_dp_ml_net" type="char*132" input_pathname="abs" category="gw_drag"
+       group="phys_ctl_nl" valid_values="" >
+Absolute filepath to the deep convection gravity wave neural net used when
+`gw_convect_dp_ml` is set.
+</entry>
+
 <entry id="use_gw_convect_sh" type="logical" category="gw_drag"
        group="phys_ctl_nl" valid_values="" >
 Whether or not to enable gravity waves produced by shallow convection.

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -1407,9 +1407,9 @@ Absolute filepath to the deep convection gravity wave neural net used when
 
 <entry id="gw_convect_dp_ml_compare" type="logical" category="gw_drag"
        group="gw_drag_nl" valid_values="" >
-  Whether or not to run a comparison of the ML deep convection gravity waves to the
-  original scheme. The scheme used to advance the simulation will be dictated by
-  `gw_convect_deep_ml`.
+  Whether or not to run a piggybacking comparison of the ML deep convection gravity 
+  waves to the original scheme. Only one scheme will be used to advance the simulation
+  as dictated by `gw_convect_deep_ml`.
 Default: .false.
 </entry>
 

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -1326,22 +1326,6 @@ Whether or not to enable gravity waves produced by deep convection.
 Default: set by build-namelist.
 </entry>
 
-<entry id="gw_convect_dp_ml" type="char*16" category="gw_drag"
-       group="phys_ctl_nl" valid_values="off,on,bothoff,bothon" >
-Whether or not to use the ML scheme for gravity waves produced by deep convection.
-   'off'     no
-   'on'      yes
-   'bothoff' run both but use default for simulation
-   'bothon'  run both but use ML for simulation
-Default: off
-</entry>
-
-<entry id="gw_convect_dp_ml_net" type="char*132" input_pathname="abs" category="gw_drag"
-       group="phys_ctl_nl" valid_values="" >
-Absolute filepath to the deep convection gravity wave neural net used when
-`gw_convect_dp_ml` is set.
-</entry>
-
 <entry id="use_gw_convect_sh" type="logical" category="gw_drag"
        group="phys_ctl_nl" valid_values="" >
 Whether or not to enable gravity waves produced by shallow convection.
@@ -1407,6 +1391,22 @@ Default: set by build-namelist.
 Efficiency associated with convective gravity waves from the Beres
 scheme (shallow convection).
 Default: set by build-namelist.
+</entry>
+
+<entry id="gw_convect_dp_ml" type="char*16" category="gw_drag"
+       group="gw_drag_nl" valid_values="off,on,bothoff,bothon" >
+Whether or not to use the ML scheme for gravity waves produced by deep convection.
+   'off'     no
+   'on'      yes
+   'bothoff' run both but use default for simulation
+   'bothon'  run both but use ML for simulation
+Default: off
+</entry>
+
+<entry id="gw_convect_dp_ml_net" type="char*132" input_pathname="abs" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Absolute filepath to the deep convection gravity wave neural net used when
+`gw_convect_dp_ml` is set.
 </entry>
 
 <entry id="effgw_cm" type="real" category="gw_drag"

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -1326,6 +1326,16 @@ Whether or not to enable gravity waves produced by deep convection.
 Default: set by build-namelist.
 </entry>
 
+<entry id="gw_convect_dp_ml" type="char*16" category="gw_drag"
+       group="phys_ctl_nl" valid_values="off,on,bothoff,bothon" >
+Whether or not to use the ML scheme for gravity waves produced by deep convection.
+   'off'     no
+   'on'      yes
+   'bothoff' run both but use default for simulation
+   'bothon'  run both but use ML for simulation
+Default: off
+</entry>
+
 <entry id="use_gw_convect_sh" type="logical" category="gw_drag"
        group="phys_ctl_nl" valid_values="" >
 Whether or not to enable gravity waves produced by shallow convection.


### PR DESCRIPTION
May close #3

Add namelist option and default for using ML scheme for deep convection gravity waves.

Added `gw_convect_dp_ml` with default `off` to switch between ML schemes.

Set as a `char*16` so we can select which parameterisations to run, and whether to run in parallel combination.

- [x] Test if we can still build and run CAM as normal with these updates, and if we can set to something else in `usr_nml_cam`