### PR TITLE
Load Neural Net

### DIFF
--- a/src/physics/cam/gw_drag.F90
+++ b/src/physics/cam/gw_drag.F90
@@ -1433,14 +1433,6 @@ subroutine gw_tend(state, pbuf, dt, ptend, cam_in, flx_heat)
   real(r8) :: zi(state%ncol,pver+1)
   !------------------------------------------------------------------------
 
-  type(torch_tensor), dimension(1) :: in_tensors
-
-  if (masterproc) then
-     write(iulog,*) 'Made a torch tensor and loaded a net!'
-  endif
-  call torch_tensor_delete(in_tensors(1))
-  call torch_module_delete(gw_convect_dp_nn)
-
   ! Make local copy of input state.
   call physics_state_copy(state, state1)
 

--- a/src/physics/cam/gw_drag.F90
+++ b/src/physics/cam/gw_drag.F90
@@ -198,6 +198,7 @@ module gw_drag
   logical :: gw_convect_dp_ml = .false.
   logical :: gw_convect_dp_ml_compare = .false.
   character(len=132) :: gw_convect_dp_ml_net_path
+  type(torch_module) :: gw_convect_dp_nn
 
 !==========================================================================
 contains
@@ -980,6 +981,12 @@ subroutine gw_init()
 
   end if
 
+  ! Set up neccessary attributes if using ML scheme for convective drag
+  if ((gw_convect_dp_ml == 'on') .or. (gw_convect_dp_ml == 'bothon')) then
+     ! Load the convective drag net from TorchScript file
+     gw_convect_dp_nn = torch_module_load(gw_convect_dp_ml_net)
+  endif
+
   if (use_gw_convect_sh) then
 
      ttend_sh_idx    = pbuf_get_index('TTEND_SH')
@@ -1417,9 +1424,6 @@ subroutine gw_tend(state, pbuf, dt, ptend, cam_in, flx_heat)
   !------------------------------------------------------------------------
 
   type(torch_tensor), dimension(1) :: in_tensors
-  type(torch_module) :: gw_convect_dp_nn
-
-  gw_convect_dp_nn = torch_module_load(gw_convect_dp_ml_net)
 
   if (masterproc) then
      write(iulog,*) 'Made a torch tensor and loaded a net!'

--- a/src/physics/cam/gw_drag.F90
+++ b/src/physics/cam/gw_drag.F90
@@ -29,6 +29,8 @@ module gw_drag
   use cam_logfile,    only: iulog
   use cam_abortutils, only: endrun
 
+  use ftorch
+
   use ref_pres,       only: do_molec_diff, nbot_molec, press_lim_idx
   use physconst,      only: cpair
 
@@ -1413,6 +1415,17 @@ subroutine gw_tend(state, pbuf, dt, ptend, cam_in, flx_heat)
   real(r8) :: zm(state%ncol,pver)
   real(r8) :: zi(state%ncol,pver+1)
   !------------------------------------------------------------------------
+
+  type(torch_tensor), dimension(1) :: in_tensors
+  type(torch_module) :: gw_convect_dp_nn
+
+  gw_convect_dp_nn = torch_module_load(gw_convect_dp_ml_net)
+
+  if (masterproc) then
+     write(iulog,*) 'Made a torch tensor and loaded a net!'
+  endif
+  call torch_tensor_delete(in_tensors(1))
+  call torch_module_delete(gw_convect_dp_nn)
 
   ! Make local copy of input state.
   call physics_state_copy(state, state1)

--- a/src/physics/cam/gw_drag.F90
+++ b/src/physics/cam/gw_drag.F90
@@ -54,6 +54,7 @@ module gw_drag
   public :: gw_drag_readnl           ! Read namelist
   public :: gw_init                  ! Initialization
   public :: gw_tend                  ! interface to actual parameterization
+  public :: gw_final                 ! Finalization
 
 !
 ! PRIVATE: Rest of the data and interfaces are private to this module
@@ -1246,6 +1247,15 @@ subroutine handle_pio_error(stat, message)
        errMsg(__FILE__, __LINE__))
 
 end subroutine handle_pio_error
+
+!==========================================================================
+
+subroutine gw_final()
+  ! Destroy neccessary attributes if using ML scheme for convective drag
+  if ((gw_convect_dp_ml == 'on') .or. (gw_convect_dp_ml == 'bothon')) then
+     call torch_module_delete(gw_convect_dp_nn)
+  endif
+end subroutine gw_final
 
 !==========================================================================
 

--- a/src/physics/cam/gw_drag.F90
+++ b/src/physics/cam/gw_drag.F90
@@ -195,6 +195,7 @@ module gw_drag
   ! Switch for using ML GW parameterisation for deep convection source
   logical :: gw_convect_dp_ml = .false.
   logical :: gw_convect_dp_ml_compare = .false.
+  character(len=132) :: gw_convect_dp_ml_net_path
 
 !==========================================================================
 contains
@@ -237,7 +238,7 @@ subroutine gw_drag_readnl(nlfile)
        gw_oro_south_fac, gw_limit_tau_without_eff, &
        gw_lndscl_sgh, gw_prndl, gw_apply_tndmax, gw_qbo_hdepth_scaling, &
        gw_top_taper, front_gaussian_width, &
-       gw_convect_dp_ml, gw_convect_dp_ml_compare
+       gw_convect_dp_ml, gw_convect_dp_ml_compare, gw_convect_dp_ml_net_path
   !----------------------------------------------------------------------
 
   if (use_simple_phys) return
@@ -346,6 +347,9 @@ subroutine gw_drag_readnl(nlfile)
 
   call mpi_bcast(gw_convect_dp_ml_compare, 1, mpi_logical, mstrid, mpicom, ierr)
   if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: gw_convect_dp_ml_compare")
+
+  call mpi_bcast(gw_convect_dp_ml_net_path, len(gw_convect_dp_ml_net_path), mpi_character, mstrid, mpicom, ierr)
+  if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: gw_convect_dp_ml_net_path")
 
   ! Check if fcrit2 was set.
   call shr_assert(fcrit2 /= unset_r8, &

--- a/src/physics/cam/physpkg.F90
+++ b/src/physics/cam/physpkg.F90
@@ -1337,6 +1337,7 @@ contains
     use microp_aero, only : microp_aero_final
     use phys_grid_ctem, only : phys_grid_ctem_final
     use nudging, only: Nudge_Model, nudging_final
+    use gw_drag, only: gw_final
 
     !-----------------------------------------------------------------------
     !
@@ -1366,6 +1367,8 @@ contains
         ! cleanup hemco
         call HCOI_Chunk_Final
     endif
+
+    call gw_final()
 
   end subroutine phys_final
 


### PR DESCRIPTION
Closes #11 

This is built on top of #9 which is itself build upon #4 and #5.

Testing using the `CAM_GW_Net` case on Derecho.

- [x] Add filepath to neural net that can be read in from the namelist
- [x] Read in and scatter to processes
- [x] Generate a net on each process in the setup
- [x] Destroy at the end of the physics routine