### PR TITLE
In code switch

### DIFF
--- a/src/physics/cam/gw_drag.F90
+++ b/src/physics/cam/gw_drag.F90
@@ -192,6 +192,10 @@ module gw_drag
   logical :: gw_top_taper=.false.
   real(r8), pointer :: vramp(:)=>null()
 
+  ! Switch for using ML GW parameterisation for deep convection source
+  logical :: gw_convect_dp_ml = .false.
+  logical :: gw_convect_dp_ml_compare = .false.
+
 !==========================================================================
 contains
 !==========================================================================
@@ -232,7 +236,8 @@ subroutine gw_drag_readnl(nlfile)
        rdg_gamma_cd_llb, trpd_leewv_rdg_gamma, bnd_rdggm, &
        gw_oro_south_fac, gw_limit_tau_without_eff, &
        gw_lndscl_sgh, gw_prndl, gw_apply_tndmax, gw_qbo_hdepth_scaling, &
-       gw_top_taper, front_gaussian_width
+       gw_top_taper, front_gaussian_width, &
+       gw_convect_dp_ml, gw_convect_dp_ml_compare
   !----------------------------------------------------------------------
 
   if (use_simple_phys) return

--- a/src/physics/cam/gw_drag.F90
+++ b/src/physics/cam/gw_drag.F90
@@ -341,6 +341,12 @@ subroutine gw_drag_readnl(nlfile)
   call mpi_bcast(front_gaussian_width, 1, mpi_real8, mstrid, mpicom, ierr)
   if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: front_gaussian_width")
 
+  call mpi_bcast(gw_convect_dp_ml, 1, mpi_logical, mstrid, mpicom, ierr)
+  if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: gw_convect_dp_ml")
+
+  call mpi_bcast(gw_convect_dp_ml_compare, 1, mpi_logical, mstrid, mpicom, ierr)
+  if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: gw_convect_dp_ml_compare")
+
   ! Check if fcrit2 was set.
   call shr_assert(fcrit2 /= unset_r8, &
        "gw_drag_readnl: fcrit2 must be set via the namelist."// &

--- a/src/physics/cam/gw_drag.F90
+++ b/src/physics/cam/gw_drag.F90
@@ -1512,7 +1512,7 @@ subroutine gw_tend(state, pbuf, dt, ptend, cam_in, flx_heat)
             qtgw = qtgw_temp
             ttgw = ttgw_temp
             utgw = utgw_temp
-            vtgw = vygw_temp
+            vtgw = vtgw_temp
         end if
      end if
 
@@ -1536,7 +1536,7 @@ subroutine gw_tend(state, pbuf, dt, ptend, cam_in, flx_heat)
             qtgw = qtgw_temp  ! in the ml scheme there is no qtgw so use qtgw = 0.0
             ttgw = ttgw_temp  ! in the ml scheme there is no ttgw so use ttgw = 0.0
             utgw = utgw_temp
-            vtgw = vygw_temp
+            vtgw = vtgw_temp
             ! in the ml scheme there is not egwdffi set, so use egwdffi = 0.0
         end if
      end if

--- a/src/physics/cam/gw_drag.F90
+++ b/src/physics/cam/gw_drag.F90
@@ -1522,7 +1522,7 @@ subroutine gw_tend(state, pbuf, dt, ptend, cam_in, flx_heat)
         end if
 
         ! Solve for the drag profile with Beres source spectrum.
-        ! Placeholder for ML scheme
+        ! Placeholder to be replaced with the ML scheme
         call gw_drag_prof(ncol, band_mid, p, src_level, tend_level, dt, &
              t, vramp,    &
              piln, rhoi,       nm,   ni, ubm,  ubi,  xv,    yv,   &
@@ -1532,6 +1532,7 @@ subroutine gw_tend(state, pbuf, dt, ptend, cam_in, flx_heat)
 
         if (gw_convect_dp_ml) then
             ! Save the results to apply to ptend for simulation updates
+            ! TODO: Check how to handle tendencies not output by ML scheme
             qtgw = qtgw_temp  ! in the ml scheme there is no qtgw so use qtgw = 0.0
             ttgw = ttgw_temp  ! in the ml scheme there is no ttgw so use ttgw = 0.0
             utgw = utgw_temp
@@ -1544,11 +1545,13 @@ subroutine gw_tend(state, pbuf, dt, ptend, cam_in, flx_heat)
      taucd = calc_taucd(ncol, band_mid%ngwv, tend_level, tau, c, xv, yv, ubi)
 
      !  add the diffusion coefficients
+     ! TODO: Check how to handle egwdffi not output by ML scheme
      do k = 1, pver+1
         egwdffi_tot(:,k) = egwdffi_tot(:,k) + egwdffi(:,k)
      end do
 
      ! Store constituents tendencies
+     ! TODO: Check how to handle qtgw not output by ML scheme
      do m=1, pcnst
         do k = 1, pver
            ptend%q(:ncol,k,m) = ptend%q(:ncol,k,m) + qtgw(:,k,m)
@@ -1568,6 +1571,7 @@ subroutine gw_tend(state, pbuf, dt, ptend, cam_in, flx_heat)
 
      ! Find energy change in the current state, and use fixer to apply
      ! the difference in lower levels.
+     ! TODO: Check how to handle ttgw not output by ML scheme
      call energy_change(dt, p, u, v, ptend%u(:ncol,:), &
           ptend%v(:ncol,:), ptend%s(:ncol,:)+ttgw, de)
      call energy_fixer(tend_level, p, de-flx_heat(:ncol), ttgw)

--- a/src/physics/cam/gw_drag.F90
+++ b/src/physics/cam/gw_drag.F90
@@ -1294,6 +1294,13 @@ subroutine gw_tend(state, pbuf, dt, ptend, cam_in, flx_heat)
   integer :: m                      ! dummy integers
   real(r8) :: qtgw(state%ncol,pver,pcnst) ! constituents tendencies
 
+  ! Temporary tendencies used with ml convect_deep scheme switching
+  ! Used to store results from both schemes for comparison
+  real(r8) :: ttgw_temp(state%ncol,pver) ! temperature tendency
+  real(r8) :: utgw_temp(state%ncol,pver) ! zonal wind tendency
+  real(r8) :: vtgw_temp(state%ncol,pver) ! meridional wind tendency
+  real(r8) :: qtgw_temp(state%ncol,pver,pcnst) ! temporary constituents tendencies
+
   ! Reynolds stress for waves propagating in each cardinal direction.
   real(r8) :: taucd(state%ncol,pver+1,4)
 
@@ -1491,13 +1498,47 @@ subroutine gw_tend(state, pbuf, dt, ptend, cam_in, flx_heat)
           u, v, ttend_dp(:ncol,:), zm, src_level, tend_level, tau, &
           ubm, ubi, xv, yv, c, hdepth, maxq0)
 
-     ! Solve for the drag profile with Beres source spectrum.
-     call gw_drag_prof(ncol, band_mid, p, src_level, tend_level, dt, &
-          t, vramp,    &
-          piln, rhoi,       nm,   ni, ubm,  ubi,  xv,    yv,   &
-          effgw,   c,       kvtt, q,  dse,  tau,  utgw,  vtgw, &
-          ttgw, qtgw, egwdffi,  gwut, dttdf, dttke,            &
-          lapply_effgw_in=gw_apply_tndmax)
+     if ((.not. gw_convect_dp_ml) .or. (gw_convect_dp_ml_compare)) then
+        ! Solve for the drag profile with Beres source spectrum.
+        call gw_drag_prof(ncol, band_mid, p, src_level, tend_level, dt, &
+             t, vramp,    &
+             piln, rhoi,       nm,   ni, ubm,  ubi,  xv,    yv,   &
+             effgw,   c,       kvtt, q,  dse,  tau,  utgw_temp,  vtgw_temp, &
+             ttgw_temp, qtgw_temp, egwdffi,  gwut, dttdf, dttke,            &
+             lapply_effgw_in=gw_apply_tndmax)
+
+        if (.not. gw_convect_dp_ml) then
+            ! Save the results to apply to ptend for simulation updates
+            qtgw = qtgw_temp
+            ttgw = ttgw_temp
+            utgw = utgw_temp
+            vtgw = vygw_temp
+        end if
+     end if
+
+     if ((gw_convect_dp_ml) .or. (gw_convect_dp_ml_compare)) then
+        if (masterproc) then
+           write(iulog,*) "Using the ML scheme for convective gravity waves."
+        end if
+
+        ! Solve for the drag profile with Beres source spectrum.
+        ! Placeholder for ML scheme
+        call gw_drag_prof(ncol, band_mid, p, src_level, tend_level, dt, &
+             t, vramp,    &
+             piln, rhoi,       nm,   ni, ubm,  ubi,  xv,    yv,   &
+             effgw,   c,       kvtt, q,  dse,  tau,  utgw_temp,  vtgw_temp, &
+             ttgw_temp, qtgw_temp, egwdffi,  gwut, dttdf, dttke,            &
+             lapply_effgw_in=gw_apply_tndmax)
+
+        if (gw_convect_dp_ml) then
+            ! Save the results to apply to ptend for simulation updates
+            qtgw = qtgw_temp  ! in the ml scheme there is no qtgw so use qtgw = 0.0
+            ttgw = ttgw_temp  ! in the ml scheme there is no ttgw so use ttgw = 0.0
+            utgw = utgw_temp
+            vtgw = vygw_temp
+            ! in the ml scheme there is not egwdffi set, so use egwdffi = 0.0
+        end if
+     end if
 
      ! Project stress into directional components.
      taucd = calc_taucd(ncol, band_mid%ngwv, tend_level, tau, c, xv, yv, ubi)


### PR DESCRIPTION
This is a duplicate of #9 which was accidentally un-merged.

Closes #8 

Note that this is build on top of (rebased) #4 and #5 

Modifications the code in gw_drag.f90 in preparation to call the alternative ML code.

- [x] retrieve namelist variable for switch
- [x] if clause around routines to call as appropriate
- [x] logic to only apply the relevant updates for the ongoing simulation

The logic is in place for the different options to be run.
Currently they all call the non-ML scheme, with a TODO in-code for modifying later once the coupling interface is written.
See comments above regarding where the tendencies are added to ptend - will require additional logic loops to select which is run.