### PR TITLE
Implement 1x1 nonlocal GW model into CAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ gw_convect_dp_ml_norms='/path/to/norms'
 
    Absolute filepath to the deep convection gravity wave normalisation weights (NetCDF) used when `gw_convect_dp_ml` is set to `.true.`.
 
-#### ML parameterisation for convection
+#### ML parameterisation for non local gravity waves
 
 To run CAM using the non local gravity wave ML model to replace all parameterisations use the following configuration
 ```fortran

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Details on creating a case can be found
 [here](https://ncar.github.io/CAM/doc/build/html/CAM6.0_users_guide/building-and-running-cam.html) on the NCAR website.
 For this work we are using the following testcase which can be set up by running:
 ```
+cd cime/scripts
 ./create_newcase --case <path_to_testcase_directory> --compset FMTHIST --res ne30pg3_ne30pg3_mg17 --project XXXXXXX --machine derecho
 ```
 from `CAM/cime/scripts/`.
@@ -87,6 +88,8 @@ the case directory as required.
 > The following settings are provided as an example. These should be tailored to your particular experiment. For more
 > information, please see the descriptions below.
 
+#### ML parameterisation for convection
+
 To run CAM using the NN to predict gravity waves and the physics-based model to _piggyback_, we can set the following settings:
 ```fortran
 gw_convect_dp_ml=.true.
@@ -112,6 +115,23 @@ gw_convect_dp_ml_norms='/path/to/norms'
 * `gw_convect_dp_ml_norms`
 
    Absolute filepath to the deep convection gravity wave normalisation weights (NetCDF) used when `gw_convect_dp_ml` is set to `.true.`.
+
+#### ML parameterisation for convection
+
+To run CAM using the non local gravity wave ML model to replace all parameterisations use the following configuration
+```fortran
+use_gw_nlgw=.true.
+gw_nlgw_model_path='/path/to/nlgw-scripted-model.pt'
+```
+
+* `use_gw_nlgw` (`logical`)
+
+   Whether or not to use the ML scheme for non local gravity waves. Default: `.false.`
+
+* `gw_nlgw_model_path`
+
+   Absolute filepath to the non local gravity wave neural net used when `use_gw_nlgw` is set to `.true.` (`.pt`
+   extension).
 
 > [!TIP]
 > Consider adding the following to generate output diagnostics of variables as desired.

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -3606,6 +3606,7 @@ if (!$simple_phys) {
     add_default($nl, 'use_gw_rdg_gamma' , 'val'=>'.false.');
     add_default($nl, 'use_gw_front_igw' , 'val'=>'.false.');
     add_default($nl, 'use_gw_convect_sh', 'val'=>'.false.');
+    add_default($nl, 'use_gw_nlgw'      , 'val'=>'.false.');
     add_default($nl, 'gw_lndscl_sgh');
     add_default($nl, 'gw_oro_south_fac');
     add_default($nl, 'gw_limit_tau_without_eff');

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -1332,6 +1332,14 @@ Whether or not to enable gravity waves produced by shallow convection.
 Default: .false.
 </entry>
 
+<entry id="use_gw_nlgw" type="logical" category="gw_drag"
+       group="phys_ctl_nl" valid_values="" >
+Whether or not to enable gravity waves produced by non-local gravity
+wave ML model.
+Default: set by build-namelist.
+</entry>
+
+
 <entry id="pgwv" type="integer" category="gw_drag"
        group="gw_drag_nl" valid_values="" >
 Gravity wave spectrum dimension (wave numbers are from -pgwv to pgwv).
@@ -1418,6 +1426,12 @@ Absolute filepath to the deep convection gravity wave neural net used when
   If `gw_convect_dp_ml` is true it will be the ML scheme, if false it will be the
   Beres scheme.
 Default: .false.
+</entry>
+
+<entry id="gw_nlgw_model_path" type="char*132" input_pathname="abs" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Absolute filepath to the non local gravity wave traced model (.pt)
+used when `use_gw_nlgw` is set to `.true.`.
 </entry>
 
 <entry id="effgw_cm" type="real" category="gw_drag"

--- a/src/physics/cam/gw_drag.F90
+++ b/src/physics/cam/gw_drag.F90
@@ -203,6 +203,7 @@ module gw_drag
   logical :: gw_convect_dp_ml_compare = .false.
   character(len=132) :: gw_convect_dp_ml_net_path
   character(len=132) :: gw_convect_dp_ml_norms
+  character(len=132) :: gw_nlgw_model_path
 
 !==========================================================================
 contains
@@ -246,7 +247,8 @@ subroutine gw_drag_readnl(nlfile)
        gw_lndscl_sgh, gw_prndl, gw_apply_tndmax, gw_qbo_hdepth_scaling, &
        gw_top_taper, front_gaussian_width, &
        gw_convect_dp_ml, gw_convect_dp_ml_compare, &
-       gw_convect_dp_ml_net_path, gw_convect_dp_ml_norms
+       gw_convect_dp_ml_net_path, gw_convect_dp_ml_norms, &
+       gw_nlgw_model_path
   !----------------------------------------------------------------------
 
   if (use_simple_phys) return
@@ -361,6 +363,9 @@ subroutine gw_drag_readnl(nlfile)
 
   call mpi_bcast(gw_convect_dp_ml_norms, len(gw_convect_dp_ml_norms), mpi_character, mstrid, mpicom, ierr)
   if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: gw_convect_dp_ml_norms")
+
+  call mpi_bcast(gw_nlgw_model_path, len(gw_nlgw_model_path), mpi_character, mstrid, mpicom, ierr)
+  if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: gw_nlgw_model_path")
 
   ! Check if fcrit2 was set.
   call shr_assert(fcrit2 /= unset_r8, &
@@ -573,7 +578,7 @@ subroutine gw_init()
        errMsg(__FILE__, __LINE__))
 
   if ( use_gw_nlgw ) then
-    call gw_nlgw_dp_init("/glade/u/home/tmeltzer/nonlocal_gwfluxes/era5_training/nlgw_ann-cnn_gpu_scripted.pt", "norms.nc")
+    call gw_nlgw_dp_init(gw_nlgw_model_path)
   end if
 
   if ( use_gw_oro ) then

--- a/src/physics/cam/gw_drag.F90
+++ b/src/physics/cam/gw_drag.F90
@@ -37,13 +37,14 @@ module gw_drag
   ! These are the actual switches for different gravity wave sources.
   use phys_control,   only: use_gw_oro, use_gw_front, use_gw_front_igw, &
                             use_gw_convect_dp, use_gw_convect_sh,       &
-                            use_simple_phys
+                            use_simple_phys, use_gw_nlgw
 
   use gw_common,      only: GWBand
   use gw_convect,     only: BeresSourceDesc
   use gw_front,       only: CMSourceDesc
   use gw_ml,          only: gw_drag_convect_dp_ml_init, gw_drag_convect_dp_ml_final, &
                             gw_drag_convect_dp_ml
+  use gw_nlgw,        only: gw_nlgw_dp_ml, gw_nlgw_dp_init, gw_nlgw_dp_finalize
 
 ! Typical module header
   implicit none
@@ -570,6 +571,10 @@ subroutine gw_init()
        gw_qbo_hdepth_scaling, errstring )
   call shr_assert(trim(errstring) == "", "gw_common_init: "//errstring// &
        errMsg(__FILE__, __LINE__))
+
+  if ( use_gw_nlgw ) then
+    call gw_nlgw_dp_init("/glade/u/home/tmeltzer/nonlocal_gwfluxes/era5_training/nlgw_ann-cnn_gpu_scripted.pt", "norms.nc")
+  end if
 
   if ( use_gw_oro ) then
 
@@ -1288,6 +1293,9 @@ subroutine gw_final()
   if ((gw_convect_dp_ml) .or. (gw_convect_dp_ml_compare)) then
      call gw_drag_convect_dp_ml_final()
   endif
+  if ( use_gw_nlgw ) then
+    call gw_nlgw_dp_finalize()
+  end if
 end subroutine gw_final
 
 !==========================================================================
@@ -1534,6 +1542,10 @@ subroutine gw_tend(state, pbuf, dt, ptend, cam_in, flx_heat)
   ! Totals that accumulate over different sources.
   egwdffi_tot = 0._r8
   flx_heat = 0._r8
+
+  if ( use_gw_nlgw ) then
+    call gw_nlgw_dp_ml(state1,ptend)
+  end if
 
   if (use_gw_convect_dp) then
      !------------------------------------------------------------------

--- a/src/physics/cam/gw_nlgw.F90
+++ b/src/physics/cam/gw_nlgw.F90
@@ -383,7 +383,7 @@ subroutine flux_to_forcing(flux, forcing)
   do col = 1, ncol
     forcing(col,1) = -1*(flux(col,2) - flux(col,1))/(pmid(col,2) - pmid(col,1))
     do level = 2, pver-1
-      forcing(col,level) = (flux(col,level+1) - flux(col,level-1)) / (pmid(col,level)*(log(pmid(col,level+1)) - log(pmid(col,level-1))))
+      forcing(col,level) = -1*(flux(col,level+1) - flux(col,level-1)) / (pmid(col,level)*(log(pmid(col,level+1)) - log(pmid(col,level-1))))
     end do
     forcing(col,pver) = -1*(flux(col,pver) - flux(col,pver-1)) / (pmid(col,pver) - pmid(col,pver-1))
   end do

--- a/src/physics/cam/gw_nlgw.F90
+++ b/src/physics/cam/gw_nlgw.F90
@@ -137,19 +137,19 @@ subroutine gw_nlgw_dp_ml(state_in, ptend)
   allocate(net_inputs(ncol, 4*pver_interp+3))
   allocate(net_outputs(ncol, 2*pver_interp))
 
-  ! dims = (ncol) TODO check ncol size vs gw_drag
-  lat = state_in%lat
-  lon = state_in%lon
-  ps = state_in%ps
-  phis = state_in%phis
+  ! dims = (ncol)
+  lat = state_in%lat(:ncol)
+  lon = state_in%lon(:ncol)
+  ps = state_in%ps(:ncol)
+  phis = state_in%phis(:ncol)
 
   ! dims = (ncol, pver)
-  u = state_in%u
-  v = state_in%v
-  t = state_in%t
-  pmid = state_in%pmid
+  u = state_in%u(:ncol,:pver)
+  v = state_in%v(:ncol,:pver)
+  t = state_in%t(:ncol,:pver)
+  pmid = state_in%pmid(:ncol,:pver)
   theta = t * (p0 / pmid) ** cappa
-  omega = state_in%omega
+  omega = state_in%omega(:ncol,:pver)
 
   ! Normalise and construct the input
   call normalise_data()
@@ -170,8 +170,8 @@ subroutine gw_nlgw_dp_ml(state_in, ptend)
   call flux_to_forcing(vflux, vtgw)
 
   ! update the tendencies
-  ptend%u(:ncol,:) = ptend%u(:ncol,:) + utgw(:,:)
-  ptend%v(:ncol,:) = ptend%v(:ncol,:) + vtgw(:,:)
+  ptend%u(:ncol,:pver) = ptend%u(:ncol,:pver) + utgw(:ncol,:pver)
+  ptend%v(:ncol,:pver) = ptend%v(:ncol,:pver) + vtgw(:ncol,:pver)
 
   ! Clean up the tensors
   call torch_delete(tensor_in)

--- a/src/physics/cam/gw_nlgw.F90
+++ b/src/physics/cam/gw_nlgw.F90
@@ -199,19 +199,17 @@ subroutine gw_nlgw_dp_ml(state_in, ptend)
 end subroutine gw_nlgw_dp_ml
 
 
-subroutine gw_nlgw_dp_init(neural_net_path, norms_path)
+subroutine gw_nlgw_dp_init(model_path)
 
-  character(len=*), intent(in) :: neural_net_path  ! Filepath to PyTorch Torchscript net
-  character(len=*), intent(in) :: norms_path       ! Filepath to NetCDF normalisation weights
+  character(len=*), intent(in) :: model_path  ! Filepath to PyTorch Torchscript net
 
   ! Load the convective drag net from TorchScript file
-  call torch_model_load(nlgw_model, neural_net_path, device_type=torch_kCUDA, device_index=0)
+  call torch_model_load(nlgw_model, model_path, device_type=torch_kCUDA, device_index=0)
   ! read in normalisation weights
   call read_norms()
 
   if (masterproc) then
-     write(iulog,*)'gw_convect_net loaded from: ', neural_net_path
-     ! write(iulog,*)'Normalisation weights loaded from: ', norms_path
+     write(iulog,*)'nlgw model loaded from: ', model_path
   endif
 
 end subroutine gw_nlgw_dp_init
@@ -229,39 +227,8 @@ end subroutine gw_nlgw_dp_finalize
 
 subroutine read_norms()
 
-  ! use netcdf
-  ! use error_messages, only: handle_ncerr
-
-  ! character(len=132), intent(in) :: norms_path  ! Filepath to NetCDF normalisation weights
-
-  ! integer :: ncid, varid, retva, ierr
-  ! character(len=*), parameter :: sub = 'gw_nlgw/F90 read_norms: '
-
-  ! Load normalisation weights from file in master process then broadcast
-  ! if (masterproc) then
-  !   ! Open the NetCDF file
-  !   call handle_ncerr( nf90_open(trim(norms_path), NF90_NOWRITE, ncid), &
-  !                      "Error opening NetCDF norms file in gw_ml.F90")
-
-  !   ! We do not need to read in dimensions here as we assume inputs match the grid.
-
-  !   ! Read in variables (means and deviations).
-  !   call handle_ncerr( nf90_inq_varid(ncid, 'U_mean', varid), &
-  !                      "Error getting U_mean varid from NetCDF Norms file in gw_ml.F90")
-  !   call handle_ncerr( nf90_get_var(ncid, varid, u_mean), &
-  !                      "Error getting U_mean varid from NetCDF Norms file in gw_ml.F90")
-
-  ! endif
-
-  ! Broadcast normalisation variables to other processes
-  ! call mpi_bcast(utgw_std, pver, mpi_real8, mstrid, mpicom, ierr)
-  ! if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: utgw_std from gw_ml.F90")
-
   ! TODO
-  ! - remove hardcoded means/std devs
-  ! - replace with netcdf load and mpi broadcast
-  ! - verify with Aman that these are correct
-  ! - verify that the denormalization is correctly applied
+  ! - replace hardcoded means/std devs with netcdf file?
 
   lat_mean = 0._r8
   lon_mean = 0._r8

--- a/src/physics/cam/gw_nlgw.F90
+++ b/src/physics/cam/gw_nlgw.F90
@@ -1,0 +1,306 @@
+module gw_nlgw
+
+!
+! This module predicts gravity wave forcings via PyTorch NNs trained to include non-local gravity wave effects
+!
+
+use gw_utils, only: r8
+use ppgrid,   only: pver !vertical levels
+use physics_types,  only: physics_state, physics_ptend
+use spmd_utils,     only: mpicom, mstrid=>masterprocid, masterproc, mpi_real8
+use cam_abortutils, only: endrun
+use cam_logfile,    only: iulog
+use physconst, only: cappa
+
+use ftorch
+
+implicit none
+
+public :: gw_nlgw_dp_ml, gw_nlgw_dp_init, gw_nlgw_dp_finalize
+
+private
+
+integer, parameter :: p0 = 100000 ! 1000 hPa (Pa)
+integer, parameter :: num_levels = 122 ! From WACCM
+
+type(torch_model) :: nlgw_model ! pytorch model
+
+integer :: ncol ! number of vertical columns
+
+real(r8), dimension(:), allocatable :: &
+  lat,     &! latitude (radians)
+  lon,     &! longitude (radians)
+  ps,      &! surface pressure
+  phis      ! surface geopotential
+real(r8), dimension(:,:), allocatable :: &
+  u,       &! zonal wind (m/s)
+  v,       &! meridional wind (m/s)
+  omega,   &! vertical pressure velocity (Pa/s)
+  t,       &! temperature (K)
+  theta,   &! potential temperature (K)
+  pmid      ! midpoint pressure (Pa)
+
+real(r8), dimension(:,:), allocatable :: &
+  utgw,    &! zonal wind tendency
+  vtgw      ! meridional wind tendency
+
+real(r8), dimension(:,:), allocatable, target :: net_inputs
+real(r8), dimension(:,:), allocatable, target :: net_outputs
+
+! normalisation means and std devs
+real(r8) :: u_mean, v_mean, omega_mean, theta_mean, lat_mean, lon_mean
+real(r8) :: u_std, v_std, omega_std, theta_std, lat_std, lon_std
+
+real(r8) :: utgw_mean, vtgw_mean
+real(r8) :: utgw_std, vtgw_std
+
+real(r8) :: era5_ak = (
+
+contains
+
+!==========================================================================
+
+subroutine gw_nlgw_dp_ml(state_in, ptend)
+
+  ! inputs
+  type(physics_state), intent(in) :: state_in
+  ! outputs
+  type(physics_ptend), intent(inout) :: ptend
+
+  !---------------------------Local storage-------------------------------
+  integer :: i
+
+  type(torch_tensor) :: tensor_in(1), tensor_out(1)
+  integer :: ninputs = 1, noutputs = 1
+  integer, dimension(2) :: layout = [1 , 2]
+
+  ncol = state_in%ncol
+
+  allocate(lat(ncol))
+  allocate(lon(ncol))
+  allocate(ps(ncol))
+  allocate(phis(ncol))
+  allocate(u(ncol,pver))
+  allocate(v(ncol,pver))
+  allocate(t(ncol,pver))
+  allocate(pmid(ncol,pver))
+  allocate(theta(ncol,pver))
+  allocate(omega(ncol,pver))
+
+  allocate(utgw(ncol,pver))
+  allocate(vtgw(ncol,pver))
+
+  allocate(net_inputs(ncol, 4*num_levels+3))
+  allocate(net_outputs(ncol, 2*num_levels))
+
+  ! dims = (ncol) TODO check ncol size vs gw_drag
+  lat = state_in%lat
+  lon = state_in%lon
+  ps = state_in%ps
+  phis = state_in%phis
+
+  ! dims = (ncol, pver)
+  u = state_in%u
+  v = state_in%v
+  t = state_in%t
+  pmid = state_in%pmid
+  theta = t * (p0 / pmid) ** cappa
+  omega = state_in%omega
+
+  ! Normalise and construct the input
+  call normalise_data()
+  call construct_input()
+
+  ! send all columns from this process
+  call torch_tensor_from_array(tensor_in(1), net_inputs, layout, torch_kCUDA)
+  call torch_tensor_from_array(tensor_out(1), net_outputs, layout, torch_kCPU)
+
+  ! Run net forward on data
+  call torch_model_forward(nlgw_model, tensor_in, tensor_out)
+
+  ! Extract and denormalise outputs
+  call extract_output()
+  call denormalise_data()
+
+!  utgw = -d(u_flux)/dp
+!  vtgw = -d(v_flux)/dp
+
+  ! update the tendencies
+  ptend%u(:ncol,:) = ptend%u(:ncol,:) + utgw(:,:)
+  ptend%v(:ncol,:) = ptend%v(:ncol,:) + vtgw(:,:)
+
+  ! Clean up the tensors
+  call torch_delete(tensor_in)
+  call torch_delete(tensor_out)
+
+  deallocate(lat)
+  deallocate(lon)
+  deallocate(ps)
+  deallocate(phis)
+  deallocate(u)
+  deallocate(v)
+  deallocate(t)
+  deallocate(pmid)
+  deallocate(theta)
+  deallocate(omega)
+
+  deallocate(utgw)
+  deallocate(vtgw)
+
+  deallocate(net_inputs)
+  deallocate(net_outputs)
+
+end subroutine gw_nlgw_dp_ml
+
+
+subroutine gw_nlgw_dp_init(neural_net_path, norms_path)
+
+  character(len=132), intent(in) :: neural_net_path  ! Filepath to PyTorch Torchscript net
+  character(len=132), intent(in) :: norms_path       ! Filepath to NetCDF normalisation weights
+
+  ! Load the convective drag net from TorchScript file
+  call torch_model_load(nlgw_model, neural_net_path, device_type=torch_kCUDA, device_index=0)
+  ! read in normalisation weights
+  call read_norms()
+
+  if (masterproc) then
+     write(iulog,*)'gw_convect_net loaded from: ', neural_net_path
+     ! write(iulog,*)'Normalisation weights loaded from: ', norms_path
+  endif
+
+end subroutine gw_nlgw_dp_init
+
+
+subroutine gw_nlgw_dp_finalize()
+
+  deallocate(net_inputs)
+  deallocate(net_outputs)
+  ! free model memory
+  call torch_delete(nlgw_model)
+
+end subroutine gw_nlgw_dp_finalize
+
+
+subroutine read_norms()
+
+  ! use netcdf
+  ! use error_messages, only: handle_ncerr
+
+  ! character(len=132), intent(in) :: norms_path  ! Filepath to NetCDF normalisation weights
+
+  ! integer :: ncid, varid, retva, ierr
+  ! character(len=*), parameter :: sub = 'gw_nlgw/F90 read_norms: '
+
+  ! Load normalisation weights from file in master process then broadcast
+  ! if (masterproc) then
+  !   ! Open the NetCDF file
+  !   call handle_ncerr( nf90_open(trim(norms_path), NF90_NOWRITE, ncid), &
+  !                      "Error opening NetCDF norms file in gw_ml.F90")
+
+  !   ! We do not need to read in dimensions here as we assume inputs match the grid.
+
+  !   ! Read in variables (means and deviations).
+  !   call handle_ncerr( nf90_inq_varid(ncid, 'U_mean', varid), &
+  !                      "Error getting U_mean varid from NetCDF Norms file in gw_ml.F90")
+  !   call handle_ncerr( nf90_get_var(ncid, varid, u_mean), &
+  !                      "Error getting U_mean varid from NetCDF Norms file in gw_ml.F90")
+
+  ! endif
+
+  ! Broadcast normalisation variables to other processes
+  ! call mpi_bcast(utgw_std, pver, mpi_real8, mstrid, mpicom, ierr)
+  ! if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: utgw_std from gw_ml.F90")
+
+  ! TODO
+  ! - remove hardcoded means/std devs
+  ! - replace with netcdf load and mpi broadcast
+  ! - verify with Aman that these are correct
+  ! - verify that the denormalization is correctly applied
+
+  lat_mean = 0._r8
+  lon_mean = 0._r8
+  u_mean = 6.395471175756457_r8
+  v_mean = 0.020313991225046_r8
+  theta_mean = 0._r8
+  omega_mean = 0.0016040905945274022_r8
+
+  lat_std = 90._r8
+  lon_std = 360._r8
+  u_std = 3._r8 * 22.175504140184618_r8
+  v_std = 3._r8 * 9.84143148277375_r8
+  theta_std = 1000._r8
+  omega_std = 0.017021397434040318_r8
+
+  utgw_mean = -0.0005112474139891424_r8
+  vtgw_mean = -0.0002982954242187403_r8
+  utgw_std = 0.0050768547492663395_r8
+  vtgw_std = 0.003792741148955207_r8
+
+end subroutine read_norms
+
+subroutine normalise_data()
+
+  lat = (lat-lat_mean)/lat_std
+  lon = (lon-lon_mean)/lon_std
+  phis = phis / 50000._r8
+  u = (u-u_mean)/u_std
+  v = (v-v_mean)/v_std
+  theta = (theta-theta_mean)/theta_std
+  omega = (omega-omega_mean)/omega_std
+  omega = omega ** (1.0/3.0) ! cube root of omega
+
+  ! TODO :: currently there is no scaling for phis?
+
+  print * , "min/max lat = " , minval(lat)   , " : " , maxval(lat)
+  print * , "min/max lon = " , minval(lon)   , " : " , maxval(lon)
+  print * , "min/max phi = " , minval(phis)  , " : " , maxval(phis)
+  print * , "min/max u   = " , minval(u)     , " : " , maxval(u)
+  print * , "min/max v   = " , minval(v)     , " : " , maxval(v)
+  print * , "min/max the = " , minval(theta) , " : " , maxval(theta)
+  print * , "min/max ome = " , minval(omega) , " : " , maxval(omega)
+
+end subroutine normalise_data
+
+subroutine construct_input()
+
+  integer :: idx_beg, idx_end
+
+  net_inputs(:,1) = lat
+  net_inputs(:,2) = lon
+  net_inputs(:,3) = phis
+
+  call interp(u, u_interp)
+
+  idx_beg = idx_end + 1
+  idx_end = idx_beg + num_levels
+  net_inputs(:,idx_beg:idx_end) = u
+  idx_beg = idx_end + 1
+  idx_end = idx_beg + num_levels
+  net_inputs(:,idx_beg:idx_end) = v
+  idx_beg = idx_end + 1
+  idx_end = idx_beg + num_levels
+  net_inputs(:,idx_beg:idx_end) = theta
+  idx_beg = idx_end + 1
+  idx_end = idx_beg + num_levels
+  net_inputs(:,idx_beg:idx_end) = omega
+
+!  u(0km:80km) 93 level -> input(0:50km) 122 levels xi0  = 0 xi121 = 50
+! TODO add interpolation (msg Aman about pressure level grids)
+
+end subroutine construct_input
+
+subroutine extract_output()
+
+  u_flux(:, :) = net_outputs(:,:num_levels)
+  v_flux(:, :) = net_outputs(:,num_levels+1:)
+
+end subroutine extract_output
+
+subroutine denormalise_data()
+
+  u_flux = u_flux**3 * u_flux_std + u_flux_mean
+  v_flux = v_flux**3 * v_flux_std + v_flux_mean
+
+end subroutine denormalise_data
+
+end module gw_nlgw

--- a/src/physics/cam/gw_nlgw.F90
+++ b/src/physics/cam/gw_nlgw.F90
@@ -41,10 +41,10 @@ real(r8), dimension(:,:), allocatable :: &
   pmid      ! midpoint pressure (Pa)
 
 real(r8), dimension(:,:), allocatable :: &
-  uflux,   &! zonal wind flux
-  vflux,   &! meridional wind flux
-  utgw,    &! zonal wind tendency
-  vtgw      ! meridional wind tendency
+  uflux,   &! zonal wind flux (Pa)
+  vflux,   &! meridional wind flux (Pa)
+  utgw,    &! zonal wind tendency (m/s^2)
+  vtgw      ! meridional wind tendency (m/s^2)
 
 real(r4), dimension(:,:), allocatable, target :: net_inputs
 real(r4), dimension(:,:), allocatable, target :: net_outputs

--- a/src/physics/cam/gw_nlgw.F90
+++ b/src/physics/cam/gw_nlgw.F90
@@ -56,7 +56,7 @@ real(r8) :: u_std, v_std, omega_std, theta_std, lat_std, lon_std
 real(r8) :: uflux_mean, vflux_mean
 real(r8) :: uflux_std, vflux_std
 
-integer, parameter :: pver_interp = 122 ! number of levels in ERA5
+integer, parameter :: pver_interp = 137 ! number of levels in ERA5
 
 real(r8), parameter :: era5_ak(137) = [ &
             1.000000000e+00_r8, 2.550781250e+00_r8, 3.884765625e+00_r8, 5.746093750e+00_r8, 8.289062500e+00_r8, 1.167968750e+01_r8, 1.610937500e+01_r8, 2.179687500e+01_r8, &
@@ -265,34 +265,26 @@ subroutine read_norms()
 
   lat_mean = 0._r8
   lon_mean = 0._r8
-  u_mean = 6.395471175756457_r8
-  v_mean = 0.020313991225046_r8
+  u_mean = 6.717847278462159_r8
+  v_mean = -0.002744777264668839_r8
   theta_mean = 0._r8
-  omega_mean = 0.0016040905945274022_r8
+  omega_mean = 0.0013401482063147452_r8
 
   lat_std = 90._r8
   lon_std = 360._r8
-  u_std = 3._r8 * 22.175504140184618_r8
-  v_std = 3._r8 * 9.84143148277375_r8
+  u_std = 20.760385183200206_r8
+  v_std = 9.877389116738264_r8
   theta_std = 1000._r8
-  omega_std = 0.017021397434040318_r8
+  omega_std = 0.11202126259282257_r8
 
-  uflux_mean = -0.0005112474139891424_r8
-  vflux_mean = -0.0002982954242187403_r8
-  uflux_std = 0.0050768547492663395_r8
-  vflux_std = 0.003792741148955207_r8
+  uflux_mean = -0.0004691528666736032_r8
+  vflux_mean = -0.0002586195082961397_r8
+  uflux_std = 0.032814051953840274_r8
+  vflux_std = 0.03024781201672967_r8
 
 end subroutine read_norms
 
 subroutine normalise_data()
-
-  ! print * , "min/max lat = " , minval(lat)   , " : " , maxval(lat)
-  ! print * , "min/max lon = " , minval(lon)   , " : " , maxval(lon)
-  ! print * , "min/max phi = " , minval(phis)  , " : " , maxval(phis)
-  ! print * , "min/max u   = " , minval(u)     , " : " , maxval(u)
-  ! print * , "min/max v   = " , minval(v)     , " : " , maxval(v)
-  ! print * , "min/max the = " , minval(theta) , " : " , maxval(theta)
-  ! print * , "min/max ome = " , minval(omega) , " : " , maxval(omega)
 
   ! lat lon are in radians (convert to degrees first)
   lat = lat * 180. / pi
@@ -300,19 +292,12 @@ subroutine normalise_data()
   lat = (lat-lat_mean)/lat_std
   lon = (lon-lon_mean)/lon_std
   phis = phis / 50000._r8
-  u = (u-u_mean)/u_std
-  v = (v-v_mean)/v_std
+
+  u = (u-u_mean)/(3._r8 * u_std)
+  v = (v-v_mean)/(3._r8 * v_std)
   theta = (theta-theta_mean)/theta_std
   omega = (omega-omega_mean)/omega_std
   omega = cbrt(omega)
-
-  ! print * , "min/max lat = " , minval(lat)   , " : " , maxval(lat)
-  ! print * , "min/max lon = " , minval(lon)   , " : " , maxval(lon)
-  ! print * , "min/max phi = " , minval(phis)  , " : " , maxval(phis)
-  ! print * , "min/max u   = " , minval(u)     , " : " , maxval(u)
-  ! print * , "min/max v   = " , minval(v)     , " : " , maxval(v)
-  ! print * , "min/max the = " , minval(theta) , " : " , maxval(theta)
-  ! print * , "min/max ome = " , minval(omega) , " : " , maxval(omega)
 
 end subroutine normalise_data
 
@@ -335,7 +320,7 @@ subroutine construct_input()
   allocate(omega_interp(ncol,pver_interp))
 
   do i = 1, ncol
-    pmid_interp(i,:) = era5_ak(137-pver_interp+1:) + ps(i) * era5_bk(137-pver_interp+1:)
+    pmid_interp(i,:) = era5_ak(:) + ps(i) * era5_bk(:)
     call lininterp(u(i,:), pmid(i,:), pver, u_interp(i,:), pmid_interp(i,:), pver_interp)
     call lininterp(v(i,:), pmid(i,:), pver, v_interp(i,:), pmid_interp(i,:), pver_interp)
     call lininterp(theta(i,:), pmid(i,:), pver, theta_interp(i,:), pmid_interp(i,:), pver_interp)
@@ -386,7 +371,7 @@ subroutine extract_output()
   vflux_interp(:, :) = net_outputs(:,pver_interp+1:)
 
   do i = 1, ncol
-    pmid_interp(i,:) = era5_ak(137-pver_interp+1:) + ps(i) * era5_bk(137-pver_interp+1:)
+    pmid_interp(i,:) = era5_ak(:) + ps(i) * era5_bk(:)
     call lininterp(uflux_interp(i,:), pmid_interp(i,:), pver_interp, uflux(i,:), pmid(i,:), pver)
     call lininterp(vflux_interp(i,:), pmid_interp(i,:), pver_interp, vflux(i,:), pmid(i,:), pver)
   end do

--- a/src/physics/cam/gw_nlgw.F90
+++ b/src/physics/cam/gw_nlgw.F90
@@ -4,13 +4,14 @@ module gw_nlgw
 ! This module predicts gravity wave forcings via PyTorch NNs trained to include non-local gravity wave effects
 !
 
-use gw_utils, only: r8
+use gw_utils, only: r8, r4
 use ppgrid,   only: pver !vertical levels
 use physics_types,  only: physics_state, physics_ptend
 use spmd_utils,     only: mpicom, mstrid=>masterprocid, masterproc, mpi_real8
 use cam_abortutils, only: endrun
 use cam_logfile,    only: iulog
-use physconst, only: cappa
+use physconst,      only: cappa, pi
+use interpolate_data, only: lininterp
 
 use ftorch
 
@@ -21,7 +22,6 @@ public :: gw_nlgw_dp_ml, gw_nlgw_dp_init, gw_nlgw_dp_finalize
 private
 
 integer, parameter :: p0 = 100000 ! 1000 hPa (Pa)
-integer, parameter :: num_levels = 122 ! From WACCM
 
 type(torch_model) :: nlgw_model ! pytorch model
 
@@ -41,20 +41,64 @@ real(r8), dimension(:,:), allocatable :: &
   pmid      ! midpoint pressure (Pa)
 
 real(r8), dimension(:,:), allocatable :: &
+  uflux,   &! zonal wind flux
+  vflux,   &! meridional wind flux
   utgw,    &! zonal wind tendency
   vtgw      ! meridional wind tendency
 
-real(r8), dimension(:,:), allocatable, target :: net_inputs
-real(r8), dimension(:,:), allocatable, target :: net_outputs
+real(r4), dimension(:,:), allocatable, target :: net_inputs
+real(r4), dimension(:,:), allocatable, target :: net_outputs
 
 ! normalisation means and std devs
 real(r8) :: u_mean, v_mean, omega_mean, theta_mean, lat_mean, lon_mean
 real(r8) :: u_std, v_std, omega_std, theta_std, lat_std, lon_std
 
-real(r8) :: utgw_mean, vtgw_mean
-real(r8) :: utgw_std, vtgw_std
+real(r8) :: uflux_mean, vflux_mean
+real(r8) :: uflux_std, vflux_std
 
-real(r8) :: era5_ak = (
+integer, parameter :: pver_interp = 122 ! number of levels in ERA5
+
+real(r8), parameter :: era5_ak(137) = [ &
+            1.000000000e+00_r8, 2.550781250e+00_r8, 3.884765625e+00_r8, 5.746093750e+00_r8, 8.289062500e+00_r8, 1.167968750e+01_r8, 1.610937500e+01_r8, 2.179687500e+01_r8, &
+            2.898437500e+01_r8, 3.793750000e+01_r8, 4.890625000e+01_r8, 6.225000000e+01_r8, 7.818750000e+01_r8, 9.712500000e+01_r8, 1.194375000e+02_r8, 1.453750000e+02_r8, &
+            1.752500000e+02_r8, 2.096250000e+02_r8, 2.487500000e+02_r8, 2.930000000e+02_r8, 3.427500000e+02_r8, 3.982500000e+02_r8, 4.600000000e+02_r8, 5.285000000e+02_r8, &
+            6.040000000e+02_r8, 6.865000000e+02_r8, 7.770000000e+02_r8, 8.750000000e+02_r8, 9.820000000e+02_r8, 1.097000000e+03_r8, 1.221000000e+03_r8, 1.355000000e+03_r8, &
+            1.498000000e+03_r8, 1.651000000e+03_r8, 1.813000000e+03_r8, 1.987000000e+03_r8, 2.170000000e+03_r8, 2.366000000e+03_r8, 2.572000000e+03_r8, 2.788000000e+03_r8, &
+            3.018000000e+03_r8, 3.258000000e+03_r8, 3.512000000e+03_r8, 3.776000000e+03_r8, 4.054000000e+03_r8, 4.344000000e+03_r8, 4.644000000e+03_r8, 4.960000000e+03_r8, &
+            5.288000000e+03_r8, 5.624000000e+03_r8, 5.976000000e+03_r8, 6.340000000e+03_r8, 6.720000000e+03_r8, 7.112000000e+03_r8, 7.520000000e+03_r8, 7.944000000e+03_r8, &
+            8.384000000e+03_r8, 8.840000000e+03_r8, 9.320000000e+03_r8, 9.816000000e+03_r8, 1.032800000e+04_r8, 1.084800000e+04_r8, 1.139200000e+04_r8, 1.193600000e+04_r8, &
+            1.248800000e+04_r8, 1.304800000e+04_r8, 1.360000000e+04_r8, 1.416000000e+04_r8, 1.470400000e+04_r8, 1.524000000e+04_r8, 1.576800000e+04_r8, 1.628000000e+04_r8, &
+            1.676800000e+04_r8, 1.723200000e+04_r8, 1.768000000e+04_r8, 1.811200000e+04_r8, 1.849600000e+04_r8, 1.886400000e+04_r8, 1.918400000e+04_r8, 1.948800000e+04_r8, &
+            1.974400000e+04_r8, 1.995200000e+04_r8, 2.014400000e+04_r8, 2.027200000e+04_r8, 2.036800000e+04_r8, 2.043200000e+04_r8, 2.043200000e+04_r8, 2.040000000e+04_r8, &
+            2.030400000e+04_r8, 2.017600000e+04_r8, 1.998400000e+04_r8, 1.974400000e+04_r8, 1.945600000e+04_r8, 1.910400000e+04_r8, 1.870400000e+04_r8, 1.825600000e+04_r8, &
+            1.774400000e+04_r8, 1.718400000e+04_r8, 1.657600000e+04_r8, 1.592800000e+04_r8, 1.524800000e+04_r8, 1.453600000e+04_r8, 1.380000000e+04_r8, 1.304800000e+04_r8, &
+            1.228800000e+04_r8, 1.152000000e+04_r8, 1.075200000e+04_r8, 9.992000000e+03_r8, 9.248000000e+03_r8, 8.520000000e+03_r8, 7.816000000e+03_r8, 7.136000000e+03_r8, &
+            6.488000000e+03_r8, 5.868000000e+03_r8, 5.280000000e+03_r8, 4.724000000e+03_r8, 4.208000000e+03_r8, 3.722000000e+03_r8, 3.274000000e+03_r8, 2.858000000e+03_r8, &
+            2.476000000e+03_r8, 2.128000000e+03_r8, 1.810000000e+03_r8, 1.524000000e+03_r8, 1.265000000e+03_r8, 1.035000000e+03_r8, 8.310000000e+02_r8, 6.515000000e+02_r8, &
+            4.962500000e+02_r8, 3.635000000e+02_r8, 2.525000000e+02_r8, 1.622500000e+02_r8, 9.243750000e+01_r8, 4.281250000e+01_r8, 1.329687500e+01_r8, 1.878906250e+00_r8, &
+            0.000000000e+00_r8]
+
+real(r8), parameter :: era5_bk(137) = [ &
+            0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, &
+            0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, &
+            0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, &
+            0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, &
+            0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, &
+            0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, &
+            0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 0.0000000000e+00_r8, 2.9802322387e-06_r8, 1.5974044799e-05_r8, &
+            4.1007995605e-05_r8, 8.4996223449e-05_r8, 1.5604496002e-04_r8, 2.6893615722e-04_r8, 4.5108795166e-04_r8, 7.2622299194e-04_r8, 1.1224746704e-03_r8, 1.6717910766e-03_r8, &
+            2.4242401123e-03_r8, 3.4141540527e-03_r8, 4.6730041503e-03_r8, 6.2561035156e-03_r8, 8.1939697265e-03_r8, 1.0536193847e-02_r8, 1.3313293457e-02_r8, 1.6571044921e-02_r8, &
+            2.0339965820e-02_r8, 2.4658203125e-02_r8, 2.9571533203e-02_r8, 3.5095214843e-02_r8, 4.1290283203e-02_r8, 4.8156738281e-02_r8, 5.5755615234e-02_r8, 6.4086914062e-02_r8, &
+            7.3181152343e-02_r8, 8.3129882812e-02_r8, 9.3872070312e-02_r8, 1.0546875000e-01_r8, 1.1798095703e-01_r8, 1.3134765625e-01_r8, 1.4575195312e-01_r8, 1.6101074218e-01_r8, &
+            1.7724609375e-01_r8, 1.9458007812e-01_r8, 2.1289062500e-01_r8, 2.3229980468e-01_r8, 2.5268554687e-01_r8, 2.7441406250e-01_r8, 2.9687500000e-01_r8, 3.2080078125e-01_r8, &
+            3.4570312500e-01_r8, 3.7133789062e-01_r8, 3.9770507812e-01_r8, 4.2480468750e-01_r8, 4.5214843750e-01_r8, 4.7998046875e-01_r8, 5.0781250000e-01_r8, 5.3564453125e-01_r8, &
+            5.6298828125e-01_r8, 5.9033203125e-01_r8, 6.1669921875e-01_r8, 6.4306640625e-01_r8, 6.6796875000e-01_r8, 6.9287109375e-01_r8, 7.1630859375e-01_r8, 7.3876953125e-01_r8, &
+            7.6025390625e-01_r8, 7.8076171875e-01_r8, 8.0029296875e-01_r8, 8.1835937500e-01_r8, 8.3544921875e-01_r8, 8.5156250000e-01_r8, 8.6669921875e-01_r8, 8.8085937500e-01_r8, &
+            8.9355468750e-01_r8, 9.0576171875e-01_r8, 9.1699218750e-01_r8, 9.2675781250e-01_r8, 9.3652343750e-01_r8, 9.4482421875e-01_r8, 9.5263671875e-01_r8, 9.5996093750e-01_r8, &
+            9.6630859375e-01_r8, 9.7216796875e-01_r8, 9.7753906250e-01_r8, 9.8242187500e-01_r8, 9.8632812500e-01_r8, 9.9023437500e-01_r8, 9.9365234375e-01_r8, 9.9609375000e-01_r8, &
+            9.9902343750e-01_r8]
+
+
 
 contains
 
@@ -68,8 +112,6 @@ subroutine gw_nlgw_dp_ml(state_in, ptend)
   type(physics_ptend), intent(inout) :: ptend
 
   !---------------------------Local storage-------------------------------
-  integer :: i
-
   type(torch_tensor) :: tensor_in(1), tensor_out(1)
   integer :: ninputs = 1, noutputs = 1
   integer, dimension(2) :: layout = [1 , 2]
@@ -87,11 +129,13 @@ subroutine gw_nlgw_dp_ml(state_in, ptend)
   allocate(theta(ncol,pver))
   allocate(omega(ncol,pver))
 
+  allocate(uflux(ncol,pver))
+  allocate(vflux(ncol,pver))
   allocate(utgw(ncol,pver))
   allocate(vtgw(ncol,pver))
 
-  allocate(net_inputs(ncol, 4*num_levels+3))
-  allocate(net_outputs(ncol, 2*num_levels))
+  allocate(net_inputs(ncol, 4*pver_interp+3))
+  allocate(net_outputs(ncol, 2*pver_interp))
 
   ! dims = (ncol) TODO check ncol size vs gw_drag
   lat = state_in%lat
@@ -122,8 +166,8 @@ subroutine gw_nlgw_dp_ml(state_in, ptend)
   call extract_output()
   call denormalise_data()
 
-!  utgw = -d(u_flux)/dp
-!  vtgw = -d(v_flux)/dp
+  call flux_to_forcing(uflux, utgw)
+  call flux_to_forcing(vflux, vtgw)
 
   ! update the tendencies
   ptend%u(:ncol,:) = ptend%u(:ncol,:) + utgw(:,:)
@@ -144,6 +188,8 @@ subroutine gw_nlgw_dp_ml(state_in, ptend)
   deallocate(theta)
   deallocate(omega)
 
+  deallocate(uflux)
+  deallocate(vflux)
   deallocate(utgw)
   deallocate(vtgw)
 
@@ -155,8 +201,8 @@ end subroutine gw_nlgw_dp_ml
 
 subroutine gw_nlgw_dp_init(neural_net_path, norms_path)
 
-  character(len=132), intent(in) :: neural_net_path  ! Filepath to PyTorch Torchscript net
-  character(len=132), intent(in) :: norms_path       ! Filepath to NetCDF normalisation weights
+  character(len=*), intent(in) :: neural_net_path  ! Filepath to PyTorch Torchscript net
+  character(len=*), intent(in) :: norms_path       ! Filepath to NetCDF normalisation weights
 
   ! Load the convective drag net from TorchScript file
   call torch_model_load(nlgw_model, neural_net_path, device_type=torch_kCUDA, device_index=0)
@@ -231,15 +277,26 @@ subroutine read_norms()
   theta_std = 1000._r8
   omega_std = 0.017021397434040318_r8
 
-  utgw_mean = -0.0005112474139891424_r8
-  vtgw_mean = -0.0002982954242187403_r8
-  utgw_std = 0.0050768547492663395_r8
-  vtgw_std = 0.003792741148955207_r8
+  uflux_mean = -0.0005112474139891424_r8
+  vflux_mean = -0.0002982954242187403_r8
+  uflux_std = 0.0050768547492663395_r8
+  vflux_std = 0.003792741148955207_r8
 
 end subroutine read_norms
 
 subroutine normalise_data()
 
+  ! print * , "min/max lat = " , minval(lat)   , " : " , maxval(lat)
+  ! print * , "min/max lon = " , minval(lon)   , " : " , maxval(lon)
+  ! print * , "min/max phi = " , minval(phis)  , " : " , maxval(phis)
+  ! print * , "min/max u   = " , minval(u)     , " : " , maxval(u)
+  ! print * , "min/max v   = " , minval(v)     , " : " , maxval(v)
+  ! print * , "min/max the = " , minval(theta) , " : " , maxval(theta)
+  ! print * , "min/max ome = " , minval(omega) , " : " , maxval(omega)
+
+  ! lat lon are in radians (convert to degrees first)
+  lat = lat * 180. / pi
+  lon = lon * 180. / pi
   lat = (lat-lat_mean)/lat_std
   lon = (lon-lon_mean)/lon_std
   phis = phis / 50000._r8
@@ -247,60 +304,131 @@ subroutine normalise_data()
   v = (v-v_mean)/v_std
   theta = (theta-theta_mean)/theta_std
   omega = (omega-omega_mean)/omega_std
-  omega = omega ** (1.0/3.0) ! cube root of omega
+  omega = cbrt(omega)
 
-  ! TODO :: currently there is no scaling for phis?
-
-  print * , "min/max lat = " , minval(lat)   , " : " , maxval(lat)
-  print * , "min/max lon = " , minval(lon)   , " : " , maxval(lon)
-  print * , "min/max phi = " , minval(phis)  , " : " , maxval(phis)
-  print * , "min/max u   = " , minval(u)     , " : " , maxval(u)
-  print * , "min/max v   = " , minval(v)     , " : " , maxval(v)
-  print * , "min/max the = " , minval(theta) , " : " , maxval(theta)
-  print * , "min/max ome = " , minval(omega) , " : " , maxval(omega)
+  ! print * , "min/max lat = " , minval(lat)   , " : " , maxval(lat)
+  ! print * , "min/max lon = " , minval(lon)   , " : " , maxval(lon)
+  ! print * , "min/max phi = " , minval(phis)  , " : " , maxval(phis)
+  ! print * , "min/max u   = " , minval(u)     , " : " , maxval(u)
+  ! print * , "min/max v   = " , minval(v)     , " : " , maxval(v)
+  ! print * , "min/max the = " , minval(theta) , " : " , maxval(theta)
+  ! print * , "min/max ome = " , minval(omega) , " : " , maxval(omega)
 
 end subroutine normalise_data
 
 subroutine construct_input()
 
-  integer :: idx_beg, idx_end
+  ! temporary arrays for interpolated values
+  real(r8), dimension(:,:), allocatable :: &
+    u_interp,       &! zonal wind (m/s)
+    v_interp,       &! meridional wind (m/s)
+    omega_interp,   &! vertical pressure velocity (Pa/s)
+    theta_interp,   &! potential temperature (K)
+    pmid_interp      ! midpoint pressure (Pa)
+
+  integer :: idx_beg, idx_end, i
+
+  allocate(pmid_interp(ncol,pver_interp))
+  allocate(u_interp(ncol,pver_interp))
+  allocate(v_interp(ncol,pver_interp))
+  allocate(theta_interp(ncol,pver_interp))
+  allocate(omega_interp(ncol,pver_interp))
+
+  do i = 1, ncol
+    pmid_interp(i,:) = era5_ak(137-pver_interp+1:) + ps(i) * era5_bk(137-pver_interp+1:)
+    call lininterp(u(i,:), pmid(i,:), pver, u_interp(i,:), pmid_interp(i,:), pver_interp)
+    call lininterp(v(i,:), pmid(i,:), pver, v_interp(i,:), pmid_interp(i,:), pver_interp)
+    call lininterp(theta(i,:), pmid(i,:), pver, theta_interp(i,:), pmid_interp(i,:), pver_interp)
+    call lininterp(omega(i,:), pmid(i,:), pver, omega_interp(i,:), pmid_interp(i,:), pver_interp)
+  end do
 
   net_inputs(:,1) = lat
   net_inputs(:,2) = lon
   net_inputs(:,3) = phis
 
-  call interp(u, u_interp)
+  idx_end = 3 ! last index written to was phis at position 3
+  idx_beg = idx_end + 1
+  idx_end = idx_beg + pver_interp - 1
+  net_inputs(:,idx_beg:idx_end) = u_interp
+  idx_beg = idx_end + 1
+  idx_end = idx_beg + pver_interp - 1
+  net_inputs(:,idx_beg:idx_end) = v_interp
+  idx_beg = idx_end + 1
+  idx_end = idx_beg + pver_interp - 1
+  net_inputs(:,idx_beg:idx_end) = theta_interp
+  idx_beg = idx_end + 1
+  idx_end = idx_beg + pver_interp - 1
+  net_inputs(:,idx_beg:idx_end) = omega_interp
 
-  idx_beg = idx_end + 1
-  idx_end = idx_beg + num_levels
-  net_inputs(:,idx_beg:idx_end) = u
-  idx_beg = idx_end + 1
-  idx_end = idx_beg + num_levels
-  net_inputs(:,idx_beg:idx_end) = v
-  idx_beg = idx_end + 1
-  idx_end = idx_beg + num_levels
-  net_inputs(:,idx_beg:idx_end) = theta
-  idx_beg = idx_end + 1
-  idx_end = idx_beg + num_levels
-  net_inputs(:,idx_beg:idx_end) = omega
-
-!  u(0km:80km) 93 level -> input(0:50km) 122 levels xi0  = 0 xi121 = 50
-! TODO add interpolation (msg Aman about pressure level grids)
+  deallocate(pmid_interp)
+  deallocate(u_interp)
+  deallocate(v_interp)
+  deallocate(theta_interp)
+  deallocate(omega_interp)
 
 end subroutine construct_input
 
 subroutine extract_output()
 
-  u_flux(:, :) = net_outputs(:,:num_levels)
-  v_flux(:, :) = net_outputs(:,num_levels+1:)
+  ! temporary arrays for interpolated values
+  real(r8), dimension(:,:), allocatable :: &
+    uflux_interp,       &! zonal wind (m/s)
+    vflux_interp,       &! meridional wind (m/s)
+    pmid_interp          ! midpoint pressure (Pa)
+
+  integer :: idx_beg, idx_end, i
+
+  allocate(pmid_interp(ncol,pver_interp))
+  allocate(uflux_interp(ncol,pver_interp))
+  allocate(vflux_interp(ncol,pver_interp))
+
+  uflux_interp(:, :) = net_outputs(:,:pver_interp)
+  vflux_interp(:, :) = net_outputs(:,pver_interp+1:)
+
+  do i = 1, ncol
+    pmid_interp(i,:) = era5_ak(137-pver_interp+1:) + ps(i) * era5_bk(137-pver_interp+1:)
+    call lininterp(uflux_interp(i,:), pmid_interp(i,:), pver_interp, uflux(i,:), pmid(i,:), pver)
+    call lininterp(vflux_interp(i,:), pmid_interp(i,:), pver_interp, vflux(i,:), pmid(i,:), pver)
+  end do
+
+  deallocate(pmid_interp)
+  deallocate(uflux_interp)
+  deallocate(vflux_interp)
 
 end subroutine extract_output
 
 subroutine denormalise_data()
 
-  u_flux = u_flux**3 * u_flux_std + u_flux_mean
-  v_flux = v_flux**3 * v_flux_std + v_flux_mean
+  uflux = uflux**3._r8 * uflux_std + uflux_mean
+  vflux = vflux**3._r8 * vflux_std + vflux_mean
 
 end subroutine denormalise_data
+
+elemental function cbrt(a) result(root)
+  real(r8), intent(in) :: a
+  real(r8), parameter :: one_third = 1._r8/3._r8
+  real(r8) :: root
+  root = sign(abs(a)**one_third, a)
+end function cbrt
+
+subroutine flux_to_forcing(flux, forcing)
+
+  real(r8), intent(in), dimension(:,:) :: flux
+  real(r8), intent(out), dimension(:,:) :: forcing ! forcing = -d(u'\omega')/d(p), units = m/s^2
+
+  integer :: level, col
+
+  ! convert fluxes to tendencies
+  ! pressure profile must be in Pascals
+
+  do col = 1, ncol
+    forcing(col,1) = -1*(flux(col,2) - flux(col,1))/(pmid(col,2) - pmid(col,1))
+    do level = 2, pver-1
+      forcing(col,level) = (flux(col,level+1) - flux(col,level-1)) / (pmid(col,level)*(log(pmid(col,level+1)) - log(pmid(col,level-1))))
+    end do
+    forcing(col,pver) = -1*(flux(col,pver) - flux(col,pver-1)) / (pmid(col,pver) - pmid(col,pver-1))
+  end do
+
+end subroutine flux_to_forcing
 
 end module gw_nlgw

--- a/src/physics/cam/gw_nlgw.F90
+++ b/src/physics/cam/gw_nlgw.F90
@@ -7,7 +7,7 @@ module gw_nlgw
 use gw_utils, only: r8, r4
 use ppgrid,   only: pver !vertical levels
 use physics_types,  only: physics_state, physics_ptend
-use spmd_utils,     only: mpicom, mstrid=>masterprocid, masterproc, mpi_real8
+use spmd_utils,     only: mpicom, mstrid=>masterprocid, masterproc, mpi_real8, iam
 use cam_abortutils, only: endrun
 use cam_logfile,    only: iulog
 use physconst,      only: cappa, pi
@@ -116,6 +116,10 @@ subroutine gw_nlgw_dp_ml(state_in, ptend)
   integer :: ninputs = 1, noutputs = 1
   integer, dimension(2) :: layout = [1 , 2]
 
+  integer :: device_id
+
+  device_id = mod(iam, 2)
+
   ncol = state_in%ncol
 
   allocate(lat(ncol))
@@ -156,7 +160,7 @@ subroutine gw_nlgw_dp_ml(state_in, ptend)
   call construct_input()
 
   ! send all columns from this process
-  call torch_tensor_from_array(tensor_in(1), net_inputs, layout, torch_kCUDA)
+  call torch_tensor_from_array(tensor_in(1), net_inputs, layout, torch_kCUDA, device_id)
   call torch_tensor_from_array(tensor_out(1), net_outputs, layout, torch_kCPU)
 
   ! Run net forward on data
@@ -202,9 +206,12 @@ end subroutine gw_nlgw_dp_ml
 subroutine gw_nlgw_dp_init(model_path)
 
   character(len=*), intent(in) :: model_path  ! Filepath to PyTorch Torchscript net
+  integer :: device_id
+
+  device_id = mod(iam, 2)
 
   ! Load the convective drag net from TorchScript file
-  call torch_model_load(nlgw_model, model_path, device_type=torch_kCUDA, device_index=0)
+  call torch_model_load(nlgw_model, model_path, device_type=torch_kCUDA, device_index=device_id)
   ! read in normalisation weights
   call read_norms()
 

--- a/src/physics/cam/gw_utils.F90
+++ b/src/physics/cam/gw_utils.F90
@@ -3,6 +3,7 @@ module gw_utils
 !
 ! This module contains utility code for the gravity wave modules.
 !
+use, intrinsic :: iso_fortran_env, only : real32
 
 implicit none
 private
@@ -10,6 +11,8 @@ save
 
 ! Real kind for gravity wave parameterization.
 integer, public, parameter :: r8 = selected_real_kind(12)
+integer, public, parameter :: r4 = real32
+
 
 ! Public interface
 public :: get_unit_vector

--- a/src/physics/cam/phys_control.F90
+++ b/src/physics/cam/phys_control.F90
@@ -93,12 +93,12 @@ logical :: prog_modal_aero ! determines whether prognostic modal aerosols are pr
 logical, public, protected :: use_hetfrz_classnuc = .false.
 
 ! Which gravity wave sources are used?
-logical, public, protected :: use_gw_oro = .false.         ! Orography.
+logical, public, protected :: use_gw_oro = .true.         ! Orography.
 logical, public, protected :: use_gw_front = .false.      ! Frontogenesis.
 logical, public, protected :: use_gw_front_igw = .false.  ! Frontogenesis to inertial spectrum.
 logical, public, protected :: use_gw_convect_dp = .false. ! Deep convection.
 logical, public, protected :: use_gw_convect_sh = .false. ! Shallow convection.
-logical, public, protected :: use_gw_nlgw = .true.       ! non local GW ML model
+logical, public, protected :: use_gw_nlgw = .false.       ! non local GW ML model
 
 ! FV dycore angular momentum correction
 logical, public, protected :: fv_am_correction = .false.
@@ -137,7 +137,7 @@ subroutine phys_ctl_readnl(nlfile)
       history_waccmx, history_chemistry, history_carma, history_clubb, history_dust, &
       history_cesm_forcing, history_scwaccm_forcing, history_chemspecies_srf, &
       do_clubb_sgs, state_debug_checks, use_hetfrz_classnuc, use_gw_oro, use_gw_front, &
-      use_gw_front_igw, use_gw_convect_dp, use_gw_convect_sh, cld_macmic_num_steps, &
+      use_gw_front_igw, use_gw_convect_dp, use_gw_convect_sh, use_gw_nlgw, cld_macmic_num_steps, &
       offline_driver, convproc_do_aer, cam_snapshot_before_num, cam_snapshot_after_num, &
       cam_take_snapshot_before, cam_take_snapshot_after, cam_physics_mesh, use_hemco, do_hb_above_clubb
    !-----------------------------------------------------------------------------
@@ -155,6 +155,15 @@ subroutine phys_ctl_readnl(nlfile)
       close(unitn)
       call freeunit(unitn)
    end if
+
+   ! if we are using the nlgw ML model we need to disable all other parameterizations
+   if (masterproc .and. use_gw_nlgw==.true.) then
+      use_gw_oro = .false.
+      use_gw_front = .false.
+      use_gw_front_igw = .false.
+      use_gw_convect_dp = .false.
+      use_gw_convect_sh = .false.
+    end if
 
    ! Broadcast namelist variables
    call mpi_bcast(deep_scheme,                 len(deep_scheme),      mpi_character, masterprocid, mpicom, ierr)
@@ -194,6 +203,7 @@ subroutine phys_ctl_readnl(nlfile)
    call mpi_bcast(use_gw_front_igw,            1,                     mpi_logical,   masterprocid, mpicom, ierr)
    call mpi_bcast(use_gw_convect_dp,           1,                     mpi_logical,   masterprocid, mpicom, ierr)
    call mpi_bcast(use_gw_convect_sh,           1,                     mpi_logical,   masterprocid, mpicom, ierr)
+   call mpi_bcast(use_gw_nlgw,                 1,                     mpi_logical,   masterprocid, mpicom, ierr)
    call mpi_bcast(cld_macmic_num_steps,        1,                     mpi_integer,   masterprocid, mpicom, ierr)
    call mpi_bcast(offline_driver,              1,                     mpi_logical,   masterprocid, mpicom, ierr)
    call mpi_bcast(convproc_do_aer,             1,                     mpi_logical,   masterprocid, mpicom, ierr)

--- a/src/physics/cam/phys_control.F90
+++ b/src/physics/cam/phys_control.F90
@@ -93,11 +93,12 @@ logical :: prog_modal_aero ! determines whether prognostic modal aerosols are pr
 logical, public, protected :: use_hetfrz_classnuc = .false.
 
 ! Which gravity wave sources are used?
-logical, public, protected :: use_gw_oro = .true.         ! Orography.
+logical, public, protected :: use_gw_oro = .false.         ! Orography.
 logical, public, protected :: use_gw_front = .false.      ! Frontogenesis.
 logical, public, protected :: use_gw_front_igw = .false.  ! Frontogenesis to inertial spectrum.
 logical, public, protected :: use_gw_convect_dp = .false. ! Deep convection.
 logical, public, protected :: use_gw_convect_sh = .false. ! Shallow convection.
+logical, public, protected :: use_gw_nlgw = .true.       ! non local GW ML model
 
 ! FV dycore angular momentum correction
 logical, public, protected :: fv_am_correction = .false.


### PR DESCRIPTION
fixes https://github.com/DataWaveProject/nonlocal_gwfluxes/issues/48
fixes https://github.com/DataWaveProject/nonlocal_gwfluxes/issues/51
fixes https://github.com/DataWaveProject/nonlocal_gwfluxes/issues/52

## Add 1x1 CNN non-local gravity wave model into CAM 

This is an initial implementation of coupling the nonlocal gw models into CAM.

- Instructions on how to run are included in the `README.md`
- Path to traced/scripted NN can be provided via `gw_nlgw_model_path` namelist var
- nlgw model can be enabled by setting `use_gw_nlgw=.true.` in the namelist
- model std dev.s and means are currently hardcoded (this could be changed in a future PR)
- era5 `ak` and `bk` coefficients are also hardcoded to interpolate between the ERA5 pressure grid and the CAM pressure grid
- currently inference takes place on the GPU and as such this requires a GPU TorchScript model

> [!NOTE]
> If you follow the instructions in the `README.md` before this is merged you need to checkout branch `nonlocal-gws` instead of `datawave_ml`

## TODO
- [x] output tendencies to fix https://github.com/DataWaveProject/nonlocal_gwfluxes/issues/52
- [x] verify model works with latest trained model (epoch 85) to fix https://github.com/DataWaveProject/nonlocal_gwfluxes/issues/51

## Merge Dependencies First
- [x] #34 
- [x] #30 