### PR TITLE
Add tendencies and fluxes to variable output

### DIFF
--- a/src/physics/cam/gw_drag.F90
+++ b/src/physics/cam/gw_drag.F90
@@ -1549,7 +1549,7 @@ subroutine gw_tend(state, pbuf, dt, ptend, cam_in, flx_heat)
   flx_heat = 0._r8
 
   if ( use_gw_nlgw ) then
-    call gw_nlgw_dp_ml(state1,ptend)
+    call gw_nlgw_dp_ml(state1,ptend,lchnk)
   end if
 
   if (use_gw_convect_dp) then

--- a/src/physics/cam/gw_nlgw.F90
+++ b/src/physics/cam/gw_nlgw.F90
@@ -12,7 +12,7 @@ use cam_abortutils, only: endrun
 use cam_logfile,    only: iulog
 use physconst,      only: cappa, pi
 use interpolate_data, only: lininterp
-use cam_history,    only: outfld
+use cam_history,    only: outfld, addfld
 
 use ftorch
 

--- a/src/physics/cam/gw_nlgw.F90
+++ b/src/physics/cam/gw_nlgw.F90
@@ -214,8 +214,6 @@ end subroutine gw_nlgw_dp_ml
 
 subroutine gw_nlgw_dp_init(model_path)
 
-  use cam_history,    only: addfld
-
   character(len=*), intent(in) :: model_path  ! Filepath to PyTorch Torchscript net
   integer :: device_id
 

--- a/src/physics/cam/gw_nlgw.F90
+++ b/src/physics/cam/gw_nlgw.F90
@@ -5,7 +5,7 @@ module gw_nlgw
 !
 
 use gw_utils, only: r8, r4
-use ppgrid,   only: pcols, pver !vertical levels
+use ppgrid,   only: pver !vertical levels
 use physics_types,  only: physics_state, physics_ptend
 use spmd_utils,     only: mpicom, mstrid=>masterprocid, masterproc, mpi_real8, iam
 use cam_abortutils, only: endrun

--- a/src/physics/cam/gw_nlgw.F90
+++ b/src/physics/cam/gw_nlgw.F90
@@ -137,7 +137,7 @@ subroutine gw_nlgw_dp_ml(state_in, ptend, lchnk)
 
   allocate(uflux(ncol,pver))
   allocate(vflux(ncol,pver))
-  allocate(utgw(pcols,pver))
+  allocate(utgw(ncol,pver))
   allocate(vtgw(ncol,pver))
 
   allocate(net_inputs(ncol, 4*pver_interp+3))
@@ -177,7 +177,7 @@ subroutine gw_nlgw_dp_ml(state_in, ptend, lchnk)
 
   ! Write UTGW and VTGW to file
   call outfld('UTGW_NL', utgw, ncol, lchnk)
-  call outfld('VTGW_NL', vtgw, ncol, lcnhk)
+  call outfld('VTGW_NL', vtgw, ncol, lchnk)
 
 
   ! update the tendencies

--- a/src/physics/cam/gw_nlgw.F90
+++ b/src/physics/cam/gw_nlgw.F90
@@ -179,6 +179,8 @@ subroutine gw_nlgw_dp_ml(state_in, ptend, lchnk)
   call outfld('UTGW_NL', utgw, ncol, lchnk)
   call outfld('VTGW_NL', vtgw, ncol, lchnk)
 
+  call outfld('UFLUX_NL', uflux, ncol, lchnk)
+  call outfld('VFLUX_NL', vflux, ncol, lchnk)
 
   ! update the tendencies
   ptend%u(:ncol,:pver) = ptend%u(:ncol,:pver) + utgw(:ncol,:pver)
@@ -230,6 +232,8 @@ subroutine gw_nlgw_dp_init(model_path)
 
   call addfld('UTGW_NL', (/ 'lev' /), 'A', 'm/s2', 'Nonlinear GW zonal wind tendency')
   call addfld('VTGW_NL', (/ 'lev' /), 'A', 'm/s2', 'Nonlinear GW meridional wind tendency')
+  call addfld('UFLUX_NL', (/ 'lev' /), 'A', 'm/s', 'Nonlinear GW zonal wind flux')
+  call addfld('VFLUX_NL', (/ 'lev' /), 'A', 'm/s', 'Nonlinear GW meridional wind flux')
 
 end subroutine gw_nlgw_dp_init
 

--- a/src/physics/cam/gw_nlgw.F90
+++ b/src/physics/cam/gw_nlgw.F90
@@ -5,7 +5,7 @@ module gw_nlgw
 !
 
 use gw_utils, only: r8, r4
-use ppgrid,   only: pver !vertical levels
+use ppgrid,   only: pcols, pver !vertical levels
 use physics_types,  only: physics_state, physics_ptend
 use spmd_utils,     only: mpicom, mstrid=>masterprocid, masterproc, mpi_real8, iam
 use cam_abortutils, only: endrun
@@ -105,10 +105,11 @@ contains
 
 !==========================================================================
 
-subroutine gw_nlgw_dp_ml(state_in, ptend)
+subroutine gw_nlgw_dp_ml(state_in, ptend, lchnk)
 
   ! inputs
   type(physics_state), intent(in) :: state_in
+  integer,             intent(in)    :: lchnk
   ! outputs
   type(physics_ptend), intent(inout) :: ptend
 
@@ -136,7 +137,7 @@ subroutine gw_nlgw_dp_ml(state_in, ptend)
 
   allocate(uflux(ncol,pver))
   allocate(vflux(ncol,pver))
-  allocate(utgw(ncol,pver))
+  allocate(utgw(pcols,pver))
   allocate(vtgw(ncol,pver))
 
   allocate(net_inputs(ncol, 4*pver_interp+3))
@@ -175,8 +176,8 @@ subroutine gw_nlgw_dp_ml(state_in, ptend)
   call flux_to_forcing(vflux, vtgw)
 
   ! Write UTGW and VTGW to file
-  call outfld('UTGW_NL', utgw, ncol, pver)
-  call outfld('VTGW_NL', vtgw, ncol, pver)
+  call outfld('UTGW_NL', utgw, ncol, lchnk)
+  call outfld('VTGW_NL', vtgw, ncol, lcnhk)
 
 
   ! update the tendencies
@@ -227,8 +228,8 @@ subroutine gw_nlgw_dp_init(model_path)
      write(iulog,*)'nlgw model loaded from: ', model_path
   endif
 
-  call addfld('UTGW_NL', (/ 'lev' /), 'U', 'm/s2', 'Nonlinear GW zonal wind tendency')
-  call addfld('VTGW_NL', (/ 'lev' /), 'U', 'm/s2', 'Nonlinear GW meridional wind tendency')
+  call addfld('UTGW_NL', (/ 'lev' /), 'A', 'm/s2', 'Nonlinear GW zonal wind tendency')
+  call addfld('VTGW_NL', (/ 'lev' /), 'A', 'm/s2', 'Nonlinear GW meridional wind tendency')
 
 end subroutine gw_nlgw_dp_init
 

--- a/src/physics/cam/gw_nlgw.F90
+++ b/src/physics/cam/gw_nlgw.F90
@@ -12,6 +12,7 @@ use cam_abortutils, only: endrun
 use cam_logfile,    only: iulog
 use physconst,      only: cappa, pi
 use interpolate_data, only: lininterp
+use cam_history,    only: outfld
 
 use ftorch
 
@@ -173,6 +174,11 @@ subroutine gw_nlgw_dp_ml(state_in, ptend)
   call flux_to_forcing(uflux, utgw)
   call flux_to_forcing(vflux, vtgw)
 
+  ! Write UTGW and VTGW to file
+  call outfld('UTGW_NL', utgw, ncol, pver)
+  call outfld('VTGW_NL', vtgw, ncol, pver)
+
+
   ! update the tendencies
   ptend%u(:ncol,:pver) = ptend%u(:ncol,:pver) + utgw(:ncol,:pver)
   ptend%v(:ncol,:pver) = ptend%v(:ncol,:pver) + vtgw(:ncol,:pver)
@@ -205,6 +211,8 @@ end subroutine gw_nlgw_dp_ml
 
 subroutine gw_nlgw_dp_init(model_path)
 
+  use cam_history,    only: addfld
+
   character(len=*), intent(in) :: model_path  ! Filepath to PyTorch Torchscript net
   integer :: device_id
 
@@ -218,6 +226,9 @@ subroutine gw_nlgw_dp_init(model_path)
   if (masterproc) then
      write(iulog,*)'nlgw model loaded from: ', model_path
   endif
+
+  call addfld('UTGW_NL', (/ 'lev' /), 'U', 'm/s2', 'Nonlinear GW zonal wind tendency')
+  call addfld('VTGW_NL', (/ 'lev' /), 'U', 'm/s2', 'Nonlinear GW meridional wind tendency')
 
 end subroutine gw_nlgw_dp_init
 


### PR DESCRIPTION
Enables `utgw` and `vtgw` variable output. 

Passes `lchnk` to `gw_nlgw_dp_ml(state1,ptend,lchnk)` as I was getting "block out of bounds" errors with ncol passed to  `outfld` function. 

This PR registers `UFLUX_NL`, `VFLUX_NL`, `UTGW_NL` and `VTGW_NL` in `gw_nlgw_dp_init` routine using `addfld`, and then outputs tendencies using `outfld`. The following changes need to be made to `user_nl_cam`:

```
nhtfrq=0,-24
mfilt=1,1400

fincl2 = 'U:I','V:I','T:I','UTGW_NL:I','VTGW_NL:I'
```
I believe 'I' corresponds to instantaneous and 'A' to time averaged. Care has to be taken to register the output variables properly. This is something I need to experiment wit.

**IMPORTANT**: Then make sure to run `./preview_namelists`. 

> NOTES: I tried with `ncol` and `pcols` passed to `outfld` and this led to the block error. 

Output successfully reports write:
```
 file CAM_non-local-intel.cam.h0.1979-01-01-00000.nc to write         288
 Opened file CAM_non-local-intel.cam.h0.1979-01-01-03600.nc to write         289
 Opened file CAM_non-local-intel.cam.h0.1979-01-01-07200.nc to write         290
 Opened file CAM_non-local-intel.cam.h0.1979-01-01-10800.nc to write         291
 Opened file CAM_non-local-intel.cam.h0.1979-01-01-14400.nc to write         292
 Opened file CAM_non-local-intel.cam.h0.1979-01-01-18000.nc to write         293
 Opened file CAM_non-local-intel.cam.h0.1979-01-01-21600.nc to write         294
 Opened file CAM_non-local-intel.cam.h0.1979-01-01-25200.nc to write         295
 Opened file CAM_non-local-intel.cam.h0.1979-01-01-28800.nc to write         296
 Opened file CAM_non-local-intel.cam.h0.1979-01-01-32400.nc to write         297
 Opened file CAM_non-local-intel.cam.h0.1979-01-01-36000.nc to write         298
 Opened file CAM_non-local-intel.cam.h0.1979-01-01-39600.nc to write         299
 Opened file CAM_non-local-intel.cam.h0.1979-01-01-43200.nc to write         300
 Opened file CAM_non-local-intel.cam.h0.1979-01-01-46800.nc to write         301
 Opened file CAM_non-local-intel.cam.h0.1979-01-01-50400.nc to write         302
 Opened file CAM_non-local-intel.cam.h0.1979-01-01-54000.nc to write         303
 Opened file CAM_non-local-intel.cam.h0.1979-01-01-57600.nc to write         304
 Opened file CAM_non-local-intel.cam.h0.1979-01-01-61200.nc to write         305
 ```
 
 And `atm_in` reports that UTGW and VTGW is properly registered. 


TODO before merging: 
- [x] Remove pcols experimentation. 
- [x] Neaten 
- [x] Add fluxes as well
- [x] Check that this compiles
- [x] Check that UTGW, VTGW, UFLUX and VFLUX are output and provide output syntax here. 
- [x] Check whether grid is output

